### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ code for the order of the returned constraints.
 
 ## Installation
 
-As for now, you can use [Carthage](https://github.com/Carthage/Carthage) or [Cocoapods](https://cocoapods.org) to install Manuscript
+As for now, you can use [Carthage](https://github.com/Carthage/Carthage) or [CocoaPods](https://cocoapods.org) to install Manuscript
 using a dependency manager or do it manually.
 
 ### Carthage
@@ -183,7 +183,7 @@ To integrate Manuscript into your Xcode project using Carthage, specify it in yo
 github "floriankrueger/Manuscript"
 ```
 
-### Cocoapods
+### CocoaPods
 
 Make sure your `Podfile` contains all of the following lines.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
